### PR TITLE
Fix encoding on search

### DIFF
--- a/src/main/java/org/gridsuite/explore/server/services/DirectoryService.java
+++ b/src/main/java/org/gridsuite/explore/server/services/DirectoryService.java
@@ -22,6 +22,7 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -196,17 +197,17 @@ public class DirectoryService implements IDirectoryElementsService {
     }
 
     public String searchElements(String userInput, String directoryUuid, String userId) {
-        String path = UriComponentsBuilder
-                .fromPath(DIRECTORIES_SERVER_ROOT_PATH + "/elements/indexation-infos")
-                .queryParam(PARAM_DIRECTORY_UUID, directoryUuid)
-                .queryParam(PARAM_USER_INPUT, userInput)
-                .toUriString();
+        URI uri = UriComponentsBuilder
+                .fromUriString(directoryServerBaseUri + DIRECTORIES_SERVER_ROOT_PATH + "/elements/indexation-infos")
+                .queryParam(PARAM_DIRECTORY_UUID, "{directoryUuid}")
+                .queryParam(PARAM_USER_INPUT, "{userInput}")
+                .build(directoryUuid, userInput);
 
         HttpHeaders headers = new HttpHeaders();
         headers.add(HEADER_USER_ID, userId);
         headers.setContentType(MediaType.APPLICATION_JSON);
         return restTemplate
-                .exchange(directoryServerBaseUri + path, HttpMethod.GET, new HttpEntity<>(headers), String.class)
+                .exchange(uri, HttpMethod.GET, new HttpEntity<>(headers), String.class)
                 .getBody();
     }
 

--- a/src/test/java/org/gridsuite/explore/server/DirectoryServiceTest.java
+++ b/src/test/java/org/gridsuite/explore/server/DirectoryServiceTest.java
@@ -1,0 +1,50 @@
+package org.gridsuite.explore.server;
+
+import org.gridsuite.explore.server.services.DirectoryService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class DirectoryServiceTest {
+
+    @MockBean
+    private RestTemplate restTemplate;
+
+    @Mock
+    private ResponseEntity<String> responseEntity;
+
+    @Autowired
+    private DirectoryService directoryService;
+
+    @Test
+    void testSearchElementsWithSpecialCharacters() {
+        String userInput = "a+éè{}\\`b";
+        String directoryUuid = UUID.randomUUID().toString();
+        String userId = "testUser";
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(responseEntity);
+
+        directoryService.searchElements(userInput, directoryUuid, userId);
+
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(restTemplate).exchange(uriCaptor.capture(), any(), any(), any(Class.class));
+        String uriString = uriCaptor.getValue().toString();
+        assertTrue(uriString.contains("userInput=a%2B%C3%A9%C3%A8%7B%7D%5C%60b"));
+    }
+}


### PR DESCRIPTION
I followed the recommendation here: https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-uri-building.html#uri-encoding to be able to search for "+" or "é" which does not work for now.