### PR TITLE
Fix get elements metadata whith elements not having `equipmentType` in their specific metadata

### DIFF
--- a/src/main/java/org/gridsuite/explore/server/services/DirectoryService.java
+++ b/src/main/java/org/gridsuite/explore/server/services/DirectoryService.java
@@ -366,8 +366,13 @@ public class DirectoryService implements IDirectoryElementsService {
 
         if (!CollectionUtils.isEmpty(equipmentTypes) && !listOfElements.isEmpty()) {
             listOfElements = listOfElements.stream()
-                    .filter(element -> "DIRECTORY".equals(element.getType())
-                            || equipmentTypes.contains(element.getSpecificMetadata().get("equipmentType")))
+                    .filter(element -> {
+                        Object equipmentType = element.getSpecificMetadata().get("equipmentType");
+                        if (equipmentType != null) { // could be null for some elements
+                            return equipmentTypes.contains(equipmentType);
+                        }
+                        return true; // keep other elements
+                    })
                     .collect(Collectors.toList());
         }
 


### PR DESCRIPTION
fix(DirectoryService): fix `getElementsMetadata` to keep elements which pass the `elementTypes` filter but doesn't have a `equipmentType` in their specific metadata