### PR TITLE
add rollback when creating or duplicating element in directory-server

### DIFF
--- a/src/main/java/org/gridsuite/explore/server/services/ExploreService.java
+++ b/src/main/java/org/gridsuite/explore/server/services/ExploreService.java
@@ -442,21 +442,20 @@ public class ExploreService {
         duplicateDirectoryElementOrDeleteElement(sourceProcessConfigUuid, newProcessConfigUuid, targetDirectoryId, userId, monitorService::delete);
     }
 
-    private void createDirectoryElementOrDeleteElement(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
-        manageFailingOfDirectory(elementAttributes, parentDirectoryUuid, userId, deleteCreatedElement, directoryService::createElement);
+    private void createDirectoryElementOrDeleteElement(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> rollback) {
+        executeWithRollback(() -> directoryService.createElement(elementAttributes, parentDirectoryUuid, userId), elementAttributes.getElementUuid(), userId, rollback);
     }
 
-    private void createDirectoryElementWithNewNameOrDeleteElement(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
-        manageFailingOfDirectory(elementAttributes, parentDirectoryUuid, userId, deleteCreatedElement,
-                (element, directoryUuid, user) -> directoryService.createElementWithNewName(element, directoryUuid, user, true));
+    private void createDirectoryElementWithNewNameOrDeleteElement(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> rollback) {
+        executeWithRollback(() -> directoryService.createElementWithNewName(elementAttributes, parentDirectoryUuid, userId, true), elementAttributes.getElementUuid(), userId, rollback);
     }
 
-    private void manageFailingOfDirectory(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement, TriConsumer<ElementAttributes, UUID, String> triConsumer) {
+    private void executeWithRollback(Runnable directoryAction, UUID elementId, String userId, BiConsumer<UUID, String> rollback) {
         try {
-            triConsumer.accept(elementAttributes, parentDirectoryUuid, userId);
+            directoryAction.run();
         } catch (Exception directoryException) {
             try {
-                deleteCreatedElement.accept(elementAttributes.getElementUuid(), userId);
+                rollback.accept(elementId, userId);
             } catch (Exception rollbackException) {
                 directoryException.addSuppressed(rollbackException);
             }
@@ -464,21 +463,7 @@ public class ExploreService {
         }
     }
 
-    private void duplicateDirectoryElementOrDeleteElement(UUID elementToDuplicate, UUID elementDuplicated, UUID targetDirectoryId, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
-        try {
-            directoryService.duplicateElement(elementToDuplicate, elementDuplicated, targetDirectoryId, userId);
-        } catch (Exception directoryException) {
-            try {
-                deleteCreatedElement.accept(elementDuplicated, userId);
-            } catch (Exception rollbackException) {
-                directoryException.addSuppressed(rollbackException);
-            }
-            throw directoryException;
-        }
-    }
-
-    @FunctionalInterface
-    public interface TriConsumer<T, U, V> {
-        void accept(T var1, U var2, V var3);
+    private void duplicateDirectoryElementOrDeleteElement(UUID elementToDuplicate, UUID elementDuplicated, UUID targetDirectoryId, String userId, BiConsumer<UUID, String> rollback) {
+        executeWithRollback(() -> directoryService.duplicateElement(elementToDuplicate, elementDuplicated, targetDirectoryId, userId), elementDuplicated, userId, rollback);
     }
 }

--- a/src/main/java/org/gridsuite/explore/server/services/ExploreService.java
+++ b/src/main/java/org/gridsuite/explore/server/services/ExploreService.java
@@ -107,7 +107,12 @@ public class ExploreService {
         String elementName = getElementName(caseInfo.caseUuid());
 
         studyService.insertStudyWithExistingCaseFile(elementAttributes.getElementUuid(), userId, caseInfo.caseUuid(), caseInfo.caseFormat(), importParams, duplicateCase, elementName);
-        directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        try {
+            directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        } catch (Exception e) {
+            studyService.delete(elementAttributes.getElementUuid(), userId);
+            throw e;
+        }
     }
 
     private @Nullable String getElementName(UUID elementUuid) {

--- a/src/main/java/org/gridsuite/explore/server/services/ExploreService.java
+++ b/src/main/java/org/gridsuite/explore/server/services/ExploreService.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 import static org.gridsuite.explore.server.error.ExploreBusinessErrorCode.EXPLORE_MAX_ELEMENTS_EXCEEDED;
@@ -107,12 +108,7 @@ public class ExploreService {
         String elementName = getElementName(caseInfo.caseUuid());
 
         studyService.insertStudyWithExistingCaseFile(elementAttributes.getElementUuid(), userId, caseInfo.caseUuid(), caseInfo.caseFormat(), importParams, duplicateCase, elementName);
-        try {
-            directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
-        } catch (Exception e) {
-            studyService.delete(elementAttributes.getElementUuid(), userId);
-            throw e;
-        }
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, studyService::delete);
     }
 
     private @Nullable String getElementName(UUID elementUuid) {
@@ -134,24 +130,24 @@ public class ExploreService {
 
     public void duplicateStudy(UUID sourceStudyUuid, UUID targetDirectoryId, String userId) {
         UUID newStudyId = studyService.duplicateStudy(sourceStudyUuid, userId);
-        directoryService.duplicateElement(sourceStudyUuid, newStudyId, targetDirectoryId, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceStudyUuid, newStudyId, targetDirectoryId, userId, studyService::delete);
     }
 
     public void createCase(String caseName, MultipartFile caseFile, String description, String userId, UUID parentDirectoryUuid) {
         UUID uuid = caseService.importCase(caseFile);
-        directoryService.createElement(new ElementAttributes(uuid, caseName, CASE, userId, 0L, description),
-                parentDirectoryUuid, userId);
+        ElementAttributes elementAttributes = new ElementAttributes(uuid, caseName, CASE, userId, 0L, description);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, caseService::delete);
     }
 
     public void persistCase(String caseName, UUID caseUuid, String description, String userId, UUID parentDirectoryUuid) {
         caseService.persistCase(caseUuid);
-        directoryService.createElement(new ElementAttributes(caseUuid, caseName, CASE, userId, 0L, description),
-            parentDirectoryUuid, userId);
+        ElementAttributes elementAttributes = new ElementAttributes(caseUuid, caseName, CASE, userId, 0L, description);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, caseService::delete);
     }
 
     public void duplicateCase(UUID sourceCaseUuid, UUID targetDirectoryId, String userId) {
         UUID newCaseId = caseService.duplicateCase(sourceCaseUuid);
-        directoryService.duplicateElement(sourceCaseUuid, newCaseId, targetDirectoryId, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceCaseUuid, newCaseId, targetDirectoryId, userId, caseService::delete);
     }
 
     public void duplicateContingencyList(UUID contingencyListsId, UUID targetDirectoryId, String userId, ContingencyListType contingencyListType) {
@@ -160,36 +156,36 @@ public class ExploreService {
             case IDENTIFIERS -> contingencyListService.duplicateIdentifierContingencyList(contingencyListsId);
             case FILTERS -> contingencyListService.duplicateFilterBasedContingencyList(contingencyListsId);
         };
-        directoryService.duplicateElement(contingencyListsId, newId, targetDirectoryId, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(contingencyListsId, newId, targetDirectoryId, userId, contingencyListService::delete);
     }
 
     public void createFormContingencyList(String listName, String content, String description, String userId, UUID parentDirectoryUuid) {
         ElementAttributes elementAttributes = new ElementAttributes(UUID.randomUUID(), listName, CONTINGENCY_LIST, userId, 0L, description);
         contingencyListService.insertFormContingencyList(elementAttributes.getElementUuid(), content);
-        directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, contingencyListService::delete);
     }
 
     public void createIdentifierContingencyList(String listName, String content, String description, String userId, UUID parentDirectoryUuid) {
         ElementAttributes elementAttributes = new ElementAttributes(UUID.randomUUID(), listName, CONTINGENCY_LIST, userId, 0L, description);
         contingencyListService.insertIdentifierContingencyList(elementAttributes.getElementUuid(), content);
-        directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, contingencyListService::delete);
     }
 
     public void createFilterBasedContingencyList(String listName, String content, String description, String userId, UUID parentDirectoryUuid) {
         ElementAttributes elementAttributes = new ElementAttributes(UUID.randomUUID(), listName, CONTINGENCY_LIST, userId, 0L, description);
         contingencyListService.insertFilterBasedContingencyList(elementAttributes.getElementUuid(), content);
-        directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, contingencyListService::delete);
     }
 
     public void createFilter(String filter, String filterName, String description, UUID parentDirectoryUuid, String userId) {
         ElementAttributes elementAttributes = new ElementAttributes(UUID.randomUUID(), filterName, FILTER, userId, 0, description);
         filterService.insertFilter(filter, elementAttributes.getElementUuid(), userId);
-        directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, filterService::delete);
     }
 
     public void duplicateFilter(UUID sourceFilterId, UUID targetDirectoryId, String userId) {
         UUID newFilterId = filterService.duplicateFilter(sourceFilterId);
-        directoryService.duplicateElement(sourceFilterId, newFilterId, targetDirectoryId, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceFilterId, newFilterId, targetDirectoryId, userId, filterService::delete);
     }
 
     public void deleteElement(UUID id, String userId) {
@@ -268,7 +264,7 @@ public class ExploreService {
     public void createParameters(String parameters, ParametersType parametersType, String parametersName, String description, UUID parentDirectoryUuid, String userId) {
         UUID parametersUuid = parametersService.createParameters(parameters, parametersType);
         ElementAttributes elementAttributes = new ElementAttributes(parametersUuid, parametersName, parametersType.name(), userId, 0, description);
-        directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, parametersService::delete);
     }
 
     public void updateParameters(UUID id, String parameters, ParametersType parametersType, String userId, String name, String description) {
@@ -278,18 +274,18 @@ public class ExploreService {
 
     public void duplicateParameters(UUID sourceId, UUID targetDirectoryId, ParametersType parametersType, String userId) {
         UUID newParametersUuid = parametersService.duplicateParameters(sourceId, parametersType);
-        directoryService.duplicateElement(sourceId, newParametersUuid, targetDirectoryId, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newParametersUuid, targetDirectoryId, userId, parametersService::delete);
     }
 
     public void createDiagramConfig(String diagramConfig, String diagramConfigName, String description, UUID parentDirectoryUuid, String userId) {
         UUID diagramConfigUuid = singleLineDiagramService.createDiagramConfig(diagramConfig);
         ElementAttributes elementAttributes = new ElementAttributes(diagramConfigUuid, diagramConfigName, DIAGRAM_CONFIG, userId, 0, description);
-        directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, singleLineDiagramService::delete);
     }
 
     public void duplicateDiagramConfig(UUID sourceId, UUID targetDirectoryId, String userId) {
         UUID newConfigUuid = singleLineDiagramService.duplicateDiagramConfig(sourceId);
-        directoryService.duplicateElement(sourceId, newConfigUuid, targetDirectoryId, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newConfigUuid, targetDirectoryId, userId, singleLineDiagramService::delete);
     }
 
     public void updateDiagramConfig(UUID id, String diagramConfig, String userId, String name, String description) {
@@ -300,7 +296,7 @@ public class ExploreService {
     public void createSpreadsheetConfig(String spreadsheetConfigDto, String configName, String description, UUID parentDirectoryUuid, String userId) {
         UUID spreadsheetConfigUuid = spreadsheetConfigService.createSpreadsheetConfig(spreadsheetConfigDto);
         ElementAttributes elementAttributes = new ElementAttributes(spreadsheetConfigUuid, configName, SPREADSHEET_CONFIG, userId, 0, description);
-        directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, spreadsheetConfigService::delete);
     }
 
     public void createSpreadsheetConfigCollection(String spreadsheetConfigCollectionDto, String collectionName, String description, UUID parentDirectoryUuid, String userId) {
@@ -315,7 +311,7 @@ public class ExploreService {
 
     private void createSpreadsheetConfigCollectionElement(UUID spreadsheetConfigUuid, String collectionName, String description, UUID parentDirectoryUuid, String userId) {
         ElementAttributes elementAttributes = new ElementAttributes(spreadsheetConfigUuid, collectionName, SPREADSHEET_CONFIG_COLLECTION, userId, 0, description);
-        directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, spreadsheetConfigCollectionService::delete);
     }
 
     public void updateSpreadsheetConfig(UUID id, String spreadsheetConfigDto, String userId, String name, String description) {
@@ -335,18 +331,18 @@ public class ExploreService {
 
     public void duplicateSpreadsheetConfig(UUID sourceId, UUID targetDirectoryId, String userId) {
         UUID newSpreadsheetConfigUuid = spreadsheetConfigService.duplicateSpreadsheetConfig(sourceId);
-        directoryService.duplicateElement(sourceId, newSpreadsheetConfigUuid, targetDirectoryId, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newSpreadsheetConfigUuid, targetDirectoryId, userId, spreadsheetConfigService::delete);
     }
 
     public void duplicateSpreadsheetConfigCollection(UUID sourceId, UUID targetDirectoryId, String userId) {
         UUID newSpreadsheetConfigUuid = spreadsheetConfigCollectionService.duplicateSpreadsheetConfigCollection(sourceId);
-        directoryService.duplicateElement(sourceId, newSpreadsheetConfigUuid, targetDirectoryId, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newSpreadsheetConfigUuid, targetDirectoryId, userId, spreadsheetConfigCollectionService::delete);
     }
 
     public void createWorkspace(UUID workspaceId, String workspaceName, String description, UUID parentDirectoryUuid, String userId) {
         UUID newWorkspaceId = workspaceService.duplicateWorkspace(workspaceId);
         ElementAttributes elementAttributes = new ElementAttributes(newWorkspaceId, workspaceName, WORKSPACE, userId, 0, description);
-        directoryService.createElement(elementAttributes, parentDirectoryUuid, userId);
+        createDirectoryElementOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, workspaceService::delete);
     }
 
     public void replaceWorkspace(UUID id, UUID workspaceId, String userId, String name, String description) {
@@ -356,7 +352,7 @@ public class ExploreService {
 
     public void duplicateWorkspace(UUID sourceId, UUID targetDirectoryId, String userId) {
         UUID newWorkspaceId = workspaceService.duplicateWorkspace(sourceId);
-        directoryService.duplicateElement(sourceId, newWorkspaceId, targetDirectoryId, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newWorkspaceId, targetDirectoryId, userId, workspaceService::delete);
     }
 
     public void createCompositeModification(List<UUID> modificationUuids, String userId, String name,
@@ -366,7 +362,7 @@ public class ExploreService {
         UUID modificationsUuid = networkModificationService.createCompositeModification(modificationUuids);
         ElementAttributes elementAttributes = new ElementAttributes(modificationsUuid, name, MODIFICATION,
                         userId, 0L, description);
-        directoryService.createElementWithNewName(elementAttributes, parentDirectoryUuid, userId, true);
+        createDirectoryElementWithNewNameOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, networkModificationService::delete);
     }
 
     public void duplicateCompositeModification(UUID sourceId, UUID parentDirectoryUuid, String userId) {
@@ -374,7 +370,7 @@ public class ExploreService {
         Map<UUID, UUID> newModificationsUuids = networkModificationService.duplicateCompositeModifications(List.of(sourceId));
         UUID newNetworkModification = newModificationsUuids.get(sourceId);
         // create corresponding directory element
-        directoryService.duplicateElement(sourceId, newNetworkModification, parentDirectoryUuid, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newNetworkModification, parentDirectoryUuid, userId, networkModificationService::delete);
     }
 
     public void assertCanCreateCase(String userId) {
@@ -433,7 +429,7 @@ public class ExploreService {
         UUID processConfigUuid = monitorService.createProcessConfig(processConfig);
         ElementAttributes elementAttributes = new ElementAttributes(processConfigUuid, name, PROCESS_CONFIG,
                 userId, 0L, description);
-        directoryService.createElementWithNewName(elementAttributes, parentDirectoryUuid, userId, true);
+        createDirectoryElementWithNewNameOrDeleteElement(elementAttributes, parentDirectoryUuid, userId, monitorService::delete);
     }
 
     public void updateProcessConfig(UUID uuid, String name, String processConfig, String description, String userId) {
@@ -443,6 +439,46 @@ public class ExploreService {
 
     public void duplicateProcessConfig(UUID sourceProcessConfigUuid, UUID targetDirectoryId, String userId) {
         UUID newProcessConfigUuid = monitorService.duplicateProcessConfig(sourceProcessConfigUuid);
-        directoryService.duplicateElement(sourceProcessConfigUuid, newProcessConfigUuid, targetDirectoryId, userId);
+        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceProcessConfigUuid, newProcessConfigUuid, targetDirectoryId, userId, monitorService::delete);
+    }
+
+    public void createDirectoryElementOrDeleteElement(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
+        manageFailingOfDirectory(elementAttributes, parentDirectoryUuid, userId, deleteCreatedElement, directoryService::createElement);
+    }
+
+    public void createDirectoryElementWithNewNameOrDeleteElement(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
+        manageFailingOfDirectory(elementAttributes, parentDirectoryUuid, userId, deleteCreatedElement,
+                (element, directoryUuid, user) -> directoryService.createElementWithNewName(element, directoryUuid, user, true));
+    }
+
+    public void duplicateDirectoryElementWithNewNameOrDeleteElement(UUID elementToDuplicate, UUID elementDuplicated, UUID targetDirectoryId, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
+        try {
+            directoryService.duplicateElement(elementToDuplicate, elementDuplicated, targetDirectoryId, userId);
+        } catch (Exception directoryException) {
+            try {
+                deleteCreatedElement.accept(elementDuplicated, userId);
+            } catch (Exception rollbackException) {
+                directoryException.addSuppressed(rollbackException);
+            }
+            throw directoryException;
+        }
+    }
+
+    private void manageFailingOfDirectory(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement, TriConsumer<ElementAttributes, UUID, String> triConsumer) {
+        try {
+            triConsumer.accept(elementAttributes, parentDirectoryUuid, userId);
+        } catch (Exception directoryException) {
+            try {
+                deleteCreatedElement.accept(elementAttributes.getElementUuid(), userId);
+            } catch (Exception rollbackException) {
+                directoryException.addSuppressed(rollbackException);
+            }
+            throw directoryException;
+        }
+    }
+
+    @FunctionalInterface
+    public interface TriConsumer<T, U, V> {
+        void accept(T var1, U var2, V var3);
     }
 }

--- a/src/main/java/org/gridsuite/explore/server/services/ExploreService.java
+++ b/src/main/java/org/gridsuite/explore/server/services/ExploreService.java
@@ -130,7 +130,7 @@ public class ExploreService {
 
     public void duplicateStudy(UUID sourceStudyUuid, UUID targetDirectoryId, String userId) {
         UUID newStudyId = studyService.duplicateStudy(sourceStudyUuid, userId);
-        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceStudyUuid, newStudyId, targetDirectoryId, userId, studyService::delete);
+        duplicateDirectoryElementOrDeleteElement(sourceStudyUuid, newStudyId, targetDirectoryId, userId, studyService::delete);
     }
 
     public void createCase(String caseName, MultipartFile caseFile, String description, String userId, UUID parentDirectoryUuid) {
@@ -147,7 +147,7 @@ public class ExploreService {
 
     public void duplicateCase(UUID sourceCaseUuid, UUID targetDirectoryId, String userId) {
         UUID newCaseId = caseService.duplicateCase(sourceCaseUuid);
-        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceCaseUuid, newCaseId, targetDirectoryId, userId, caseService::delete);
+        duplicateDirectoryElementOrDeleteElement(sourceCaseUuid, newCaseId, targetDirectoryId, userId, caseService::delete);
     }
 
     public void duplicateContingencyList(UUID contingencyListsId, UUID targetDirectoryId, String userId, ContingencyListType contingencyListType) {
@@ -156,7 +156,7 @@ public class ExploreService {
             case IDENTIFIERS -> contingencyListService.duplicateIdentifierContingencyList(contingencyListsId);
             case FILTERS -> contingencyListService.duplicateFilterBasedContingencyList(contingencyListsId);
         };
-        duplicateDirectoryElementWithNewNameOrDeleteElement(contingencyListsId, newId, targetDirectoryId, userId, contingencyListService::delete);
+        duplicateDirectoryElementOrDeleteElement(contingencyListsId, newId, targetDirectoryId, userId, contingencyListService::delete);
     }
 
     public void createFormContingencyList(String listName, String content, String description, String userId, UUID parentDirectoryUuid) {
@@ -185,7 +185,7 @@ public class ExploreService {
 
     public void duplicateFilter(UUID sourceFilterId, UUID targetDirectoryId, String userId) {
         UUID newFilterId = filterService.duplicateFilter(sourceFilterId);
-        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceFilterId, newFilterId, targetDirectoryId, userId, filterService::delete);
+        duplicateDirectoryElementOrDeleteElement(sourceFilterId, newFilterId, targetDirectoryId, userId, filterService::delete);
     }
 
     public void deleteElement(UUID id, String userId) {
@@ -274,7 +274,7 @@ public class ExploreService {
 
     public void duplicateParameters(UUID sourceId, UUID targetDirectoryId, ParametersType parametersType, String userId) {
         UUID newParametersUuid = parametersService.duplicateParameters(sourceId, parametersType);
-        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newParametersUuid, targetDirectoryId, userId, parametersService::delete);
+        duplicateDirectoryElementOrDeleteElement(sourceId, newParametersUuid, targetDirectoryId, userId, parametersService::delete);
     }
 
     public void createDiagramConfig(String diagramConfig, String diagramConfigName, String description, UUID parentDirectoryUuid, String userId) {
@@ -285,7 +285,7 @@ public class ExploreService {
 
     public void duplicateDiagramConfig(UUID sourceId, UUID targetDirectoryId, String userId) {
         UUID newConfigUuid = singleLineDiagramService.duplicateDiagramConfig(sourceId);
-        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newConfigUuid, targetDirectoryId, userId, singleLineDiagramService::delete);
+        duplicateDirectoryElementOrDeleteElement(sourceId, newConfigUuid, targetDirectoryId, userId, singleLineDiagramService::delete);
     }
 
     public void updateDiagramConfig(UUID id, String diagramConfig, String userId, String name, String description) {
@@ -331,12 +331,12 @@ public class ExploreService {
 
     public void duplicateSpreadsheetConfig(UUID sourceId, UUID targetDirectoryId, String userId) {
         UUID newSpreadsheetConfigUuid = spreadsheetConfigService.duplicateSpreadsheetConfig(sourceId);
-        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newSpreadsheetConfigUuid, targetDirectoryId, userId, spreadsheetConfigService::delete);
+        duplicateDirectoryElementOrDeleteElement(sourceId, newSpreadsheetConfigUuid, targetDirectoryId, userId, spreadsheetConfigService::delete);
     }
 
     public void duplicateSpreadsheetConfigCollection(UUID sourceId, UUID targetDirectoryId, String userId) {
         UUID newSpreadsheetConfigUuid = spreadsheetConfigCollectionService.duplicateSpreadsheetConfigCollection(sourceId);
-        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newSpreadsheetConfigUuid, targetDirectoryId, userId, spreadsheetConfigCollectionService::delete);
+        duplicateDirectoryElementOrDeleteElement(sourceId, newSpreadsheetConfigUuid, targetDirectoryId, userId, spreadsheetConfigCollectionService::delete);
     }
 
     public void createWorkspace(UUID workspaceId, String workspaceName, String description, UUID parentDirectoryUuid, String userId) {
@@ -352,7 +352,7 @@ public class ExploreService {
 
     public void duplicateWorkspace(UUID sourceId, UUID targetDirectoryId, String userId) {
         UUID newWorkspaceId = workspaceService.duplicateWorkspace(sourceId);
-        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newWorkspaceId, targetDirectoryId, userId, workspaceService::delete);
+        duplicateDirectoryElementOrDeleteElement(sourceId, newWorkspaceId, targetDirectoryId, userId, workspaceService::delete);
     }
 
     public void createCompositeModification(List<UUID> modificationUuids, String userId, String name,
@@ -370,7 +370,7 @@ public class ExploreService {
         Map<UUID, UUID> newModificationsUuids = networkModificationService.duplicateCompositeModifications(List.of(sourceId));
         UUID newNetworkModification = newModificationsUuids.get(sourceId);
         // create corresponding directory element
-        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceId, newNetworkModification, parentDirectoryUuid, userId, networkModificationService::delete);
+        duplicateDirectoryElementOrDeleteElement(sourceId, newNetworkModification, parentDirectoryUuid, userId, networkModificationService::delete);
     }
 
     public void assertCanCreateCase(String userId) {
@@ -439,29 +439,16 @@ public class ExploreService {
 
     public void duplicateProcessConfig(UUID sourceProcessConfigUuid, UUID targetDirectoryId, String userId) {
         UUID newProcessConfigUuid = monitorService.duplicateProcessConfig(sourceProcessConfigUuid);
-        duplicateDirectoryElementWithNewNameOrDeleteElement(sourceProcessConfigUuid, newProcessConfigUuid, targetDirectoryId, userId, monitorService::delete);
+        duplicateDirectoryElementOrDeleteElement(sourceProcessConfigUuid, newProcessConfigUuid, targetDirectoryId, userId, monitorService::delete);
     }
 
-    public void createDirectoryElementOrDeleteElement(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
+    private void createDirectoryElementOrDeleteElement(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
         manageFailingOfDirectory(elementAttributes, parentDirectoryUuid, userId, deleteCreatedElement, directoryService::createElement);
     }
 
-    public void createDirectoryElementWithNewNameOrDeleteElement(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
+    private void createDirectoryElementWithNewNameOrDeleteElement(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
         manageFailingOfDirectory(elementAttributes, parentDirectoryUuid, userId, deleteCreatedElement,
                 (element, directoryUuid, user) -> directoryService.createElementWithNewName(element, directoryUuid, user, true));
-    }
-
-    public void duplicateDirectoryElementWithNewNameOrDeleteElement(UUID elementToDuplicate, UUID elementDuplicated, UUID targetDirectoryId, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
-        try {
-            directoryService.duplicateElement(elementToDuplicate, elementDuplicated, targetDirectoryId, userId);
-        } catch (Exception directoryException) {
-            try {
-                deleteCreatedElement.accept(elementDuplicated, userId);
-            } catch (Exception rollbackException) {
-                directoryException.addSuppressed(rollbackException);
-            }
-            throw directoryException;
-        }
     }
 
     private void manageFailingOfDirectory(ElementAttributes elementAttributes, UUID parentDirectoryUuid, String userId, BiConsumer<UUID, String> deleteCreatedElement, TriConsumer<ElementAttributes, UUID, String> triConsumer) {
@@ -470,6 +457,19 @@ public class ExploreService {
         } catch (Exception directoryException) {
             try {
                 deleteCreatedElement.accept(elementAttributes.getElementUuid(), userId);
+            } catch (Exception rollbackException) {
+                directoryException.addSuppressed(rollbackException);
+            }
+            throw directoryException;
+        }
+    }
+
+    private void duplicateDirectoryElementOrDeleteElement(UUID elementToDuplicate, UUID elementDuplicated, UUID targetDirectoryId, String userId, BiConsumer<UUID, String> deleteCreatedElement) {
+        try {
+            directoryService.duplicateElement(elementToDuplicate, elementDuplicated, targetDirectoryId, userId);
+        } catch (Exception directoryException) {
+            try {
+                deleteCreatedElement.accept(elementDuplicated, userId);
             } catch (Exception rollbackException) {
                 directoryException.addSuppressed(rollbackException);
             }

--- a/src/test/java/org/gridsuite/explore/server/ExploreServiceExceptionTest.java
+++ b/src/test/java/org/gridsuite/explore/server/ExploreServiceExceptionTest.java
@@ -11,6 +11,7 @@ import org.gridsuite.explore.server.services.ExploreService;
 import org.gridsuite.explore.server.services.FilterService;
 import org.gridsuite.explore.server.services.NetworkModificationService;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -53,20 +54,22 @@ public class ExploreServiceExceptionTest {
         String message = assertThrows(RuntimeException.class, () -> exploreService.createFilter("filterId",
                 "filterName", "description", UUID.randomUUID(), "userId"))
                 .getMessage();
-        verify(filterService, times(1)).insertFilter(any(), any(), any());
-        verify(filterService, times(1)).delete(any(), any());
+        ArgumentCaptor<UUID> createdFilterId = ArgumentCaptor.forClass(UUID.class);
+        verify(filterService, times(1)).insertFilter(any(), createdFilterId.capture(), eq("userId"));
+        verify(filterService, times(1)).delete(eq(createdFilterId.getValue()), eq("userId"));
         assertEquals(creatingErrorMessage, message);
         reset(filterService);
 
         // duplication
         String duplicateErrorMessage = "error when duplicating element from directory server";
         when(directoryService.duplicateElement(any(), any(), any(), any())).thenThrow(new RuntimeException(duplicateErrorMessage));
-        when(filterService.duplicateFilter(any())).thenReturn(UUID.randomUUID());
+        UUID duplicatedFilterId = UUID.randomUUID();
+        when(filterService.duplicateFilter(any())).thenReturn(duplicatedFilterId);
 
         message = assertThrows(RuntimeException.class, () -> exploreService.duplicateFilter(UUID.randomUUID(), UUID.randomUUID(), "userId"))
                 .getMessage();
         verify(filterService, times(1)).duplicateFilter(any());
-        verify(filterService, times(1)).delete(any(), any());
+        verify(filterService, times(1)).delete(eq(duplicatedFilterId), any());
         assertEquals(duplicateErrorMessage, message);
     }
 
@@ -74,13 +77,14 @@ public class ExploreServiceExceptionTest {
     void testDirectoryServerCrashesWithNetworkModification() {
         String creatingErrorMessage = "error when creating element from directory server";
         when(directoryService.createElementWithNewName(any(), any(), any(), anyBoolean())).thenThrow(new RuntimeException(creatingErrorMessage));
-        when(networkModificationService.createCompositeModification(anyList())).thenReturn(UUID.randomUUID());
+        UUID createdCompositeModificationId = UUID.randomUUID();
+        when(networkModificationService.createCompositeModification(anyList())).thenReturn(createdCompositeModificationId);
 
         String message = assertThrows(RuntimeException.class, () -> exploreService.createCompositeModification(List.of(UUID.randomUUID()),
                 "userId", "name", "description", UUID.randomUUID()))
                 .getMessage();
         verify(networkModificationService, times(1)).createCompositeModification(any());
-        verify(networkModificationService, times(1)).delete(any(), any());
+        verify(networkModificationService, times(1)).delete(eq(createdCompositeModificationId), any());
         assertEquals(creatingErrorMessage, message);
     }
 }

--- a/src/test/java/org/gridsuite/explore/server/ExploreServiceExceptionTest.java
+++ b/src/test/java/org/gridsuite/explore/server/ExploreServiceExceptionTest.java
@@ -82,9 +82,9 @@ class ExploreServiceExceptionTest {
         UUID createdCompositeModificationId = UUID.randomUUID();
         when(networkModificationService.createCompositeModification(anyList())).thenReturn(createdCompositeModificationId);
 
-        UUID modificationUuid = UUID.randomUUID();
+        List<UUID> modificationUuids = List.of(UUID.randomUUID());
         UUID parentDirectoryUuid = UUID.randomUUID();
-        String message = assertThrows(RuntimeException.class, () -> exploreService.createCompositeModification(List.of(modificationUuid),
+        String message = assertThrows(RuntimeException.class, () -> exploreService.createCompositeModification(modificationUuids,
                 "userId", "name", "description", parentDirectoryUuid))
                 .getMessage();
         verify(networkModificationService, times(1)).createCompositeModification(any());

--- a/src/test/java/org/gridsuite/explore/server/ExploreServiceExceptionTest.java
+++ b/src/test/java/org/gridsuite/explore/server/ExploreServiceExceptionTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
  */
 @SpringBootTest
 @AutoConfigureMockMvc
-public class ExploreServiceExceptionTest {
+class ExploreServiceExceptionTest {
 
     @MockitoBean
     private DirectoryService directoryService;
@@ -50,13 +50,13 @@ public class ExploreServiceExceptionTest {
         when(directoryService.createElement(any(), any(), any())).thenThrow(new RuntimeException(creatingErrorMessage));
         doNothing().when(filterService).insertFilter(any(), any(), any());
         doNothing().when(filterService).delete(any(), any());
-
+        UUID parentDirectoryUuid = UUID.randomUUID();
         String message = assertThrows(RuntimeException.class, () -> exploreService.createFilter("filterId",
-                "filterName", "description", UUID.randomUUID(), "userId"))
+                "filterName", "description", parentDirectoryUuid, "userId"))
                 .getMessage();
         ArgumentCaptor<UUID> createdFilterId = ArgumentCaptor.forClass(UUID.class);
         verify(filterService, times(1)).insertFilter(any(), createdFilterId.capture(), eq("userId"));
-        verify(filterService, times(1)).delete(eq(createdFilterId.getValue()), eq("userId"));
+        verify(filterService, times(1)).delete(createdFilterId.getValue(), "userId");
         assertEquals(creatingErrorMessage, message);
         reset(filterService);
 
@@ -66,7 +66,9 @@ public class ExploreServiceExceptionTest {
         UUID duplicatedFilterId = UUID.randomUUID();
         when(filterService.duplicateFilter(any())).thenReturn(duplicatedFilterId);
 
-        message = assertThrows(RuntimeException.class, () -> exploreService.duplicateFilter(UUID.randomUUID(), UUID.randomUUID(), "userId"))
+        UUID sourceFilterId = UUID.randomUUID();
+        UUID targetDirectoryId = UUID.randomUUID();
+        message = assertThrows(RuntimeException.class, () -> exploreService.duplicateFilter(sourceFilterId, targetDirectoryId, "userId"))
                 .getMessage();
         verify(filterService, times(1)).duplicateFilter(any());
         verify(filterService, times(1)).delete(eq(duplicatedFilterId), any());
@@ -80,8 +82,10 @@ public class ExploreServiceExceptionTest {
         UUID createdCompositeModificationId = UUID.randomUUID();
         when(networkModificationService.createCompositeModification(anyList())).thenReturn(createdCompositeModificationId);
 
-        String message = assertThrows(RuntimeException.class, () -> exploreService.createCompositeModification(List.of(UUID.randomUUID()),
-                "userId", "name", "description", UUID.randomUUID()))
+        UUID modificationUuid = UUID.randomUUID();
+        UUID parentDirectoryUuid = UUID.randomUUID();
+        String message = assertThrows(RuntimeException.class, () -> exploreService.createCompositeModification(List.of(modificationUuid),
+                "userId", "name", "description", parentDirectoryUuid))
                 .getMessage();
         verify(networkModificationService, times(1)).createCompositeModification(any());
         verify(networkModificationService, times(1)).delete(eq(createdCompositeModificationId), any());

--- a/src/test/java/org/gridsuite/explore/server/ExploreServiceExceptionTest.java
+++ b/src/test/java/org/gridsuite/explore/server/ExploreServiceExceptionTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.explore.server;
+
+import org.gridsuite.explore.server.services.DirectoryService;
+import org.gridsuite.explore.server.services.ExploreService;
+import org.gridsuite.explore.server.services.FilterService;
+import org.gridsuite.explore.server.services.NetworkModificationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Etienne Lesot <etienne.lesot at rte-france.com>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ExploreServiceExceptionTest {
+
+    @MockitoBean
+    private DirectoryService directoryService;
+
+    @MockitoBean
+    private FilterService filterService;
+
+    @Autowired
+    private ExploreService exploreService;
+
+    @MockitoBean
+    private NetworkModificationService networkModificationService;
+
+    @Test
+    void testDirectoryServerCrashesWithFilter() {
+        // creation
+        String creatingErrorMessage = "error when creating element from directory server";
+        when(directoryService.createElement(any(), any(), any())).thenThrow(new RuntimeException(creatingErrorMessage));
+        doNothing().when(filterService).insertFilter(any(), any(), any());
+        doNothing().when(filterService).delete(any(), any());
+
+        String message = assertThrows(RuntimeException.class, () -> exploreService.createFilter("filterId",
+                "filterName", "description", UUID.randomUUID(), "userId"))
+                .getMessage();
+        verify(filterService, times(1)).insertFilter(any(), any(), any());
+        verify(filterService, times(1)).delete(any(), any());
+        assertEquals(creatingErrorMessage, message);
+        reset(filterService);
+
+        // duplication
+        String duplicateErrorMessage = "error when duplicating element from directory server";
+        when(directoryService.duplicateElement(any(), any(), any(), any())).thenThrow(new RuntimeException(duplicateErrorMessage));
+        when(filterService.duplicateFilter(any())).thenReturn(UUID.randomUUID());
+
+        message = assertThrows(RuntimeException.class, () -> exploreService.duplicateFilter(UUID.randomUUID(), UUID.randomUUID(), "userId"))
+                .getMessage();
+        verify(filterService, times(1)).duplicateFilter(any());
+        verify(filterService, times(1)).delete(any(), any());
+        assertEquals(duplicateErrorMessage, message);
+    }
+
+    @Test
+    void testDirectoryServerCrashesWithNetworkModification() {
+        String creatingErrorMessage = "error when creating element from directory server";
+        when(directoryService.createElementWithNewName(any(), any(), any(), anyBoolean())).thenThrow(new RuntimeException(creatingErrorMessage));
+        when(networkModificationService.createCompositeModification(anyList())).thenReturn(UUID.randomUUID());
+
+        String message = assertThrows(RuntimeException.class, () -> exploreService.createCompositeModification(List.of(UUID.randomUUID()),
+                "userId", "name", "description", UUID.randomUUID()))
+                .getMessage();
+        verify(networkModificationService, times(1)).createCompositeModification(any());
+        verify(networkModificationService, times(1)).delete(any(), any());
+        assertEquals(creatingErrorMessage, message);
+    }
+}

--- a/src/test/java/org/gridsuite/explore/server/ExploreServiceExceptionTest.java
+++ b/src/test/java/org/gridsuite/explore/server/ExploreServiceExceptionTest.java
@@ -91,4 +91,26 @@ class ExploreServiceExceptionTest {
         verify(networkModificationService, times(1)).delete(eq(createdCompositeModificationId), any());
         assertEquals(creatingErrorMessage, message);
     }
+
+    @Test
+    void testDirectoryServerCrashesAndDeleteElementToo() {
+        // creation
+        String creatingErrorMessage = "error when creating element from directory server";
+        String deletingErrorMessage = "error when deleting filter element";
+        when(directoryService.createElement(any(), any(), any())).thenThrow(new RuntimeException(creatingErrorMessage));
+        doNothing().when(filterService).insertFilter(any(), any(), any());
+        doThrow(new RuntimeException(deletingErrorMessage)).when(filterService).delete(any(), any());
+        UUID parentDirectoryUuid = UUID.randomUUID();
+        Throwable throwable = assertThrows(RuntimeException.class, () -> exploreService.createFilter("filterId",
+                "filterName", "description", parentDirectoryUuid, "userId"));
+        String message = throwable.getMessage();
+        assertEquals(creatingErrorMessage, message);
+        assertEquals(1, throwable.getSuppressed().length);
+        assertEquals(deletingErrorMessage, throwable.getSuppressed()[0].getMessage());
+
+        ArgumentCaptor<UUID> createdFilterId = ArgumentCaptor.forClass(UUID.class);
+        verify(filterService, times(1)).insertFilter(any(), createdFilterId.capture(), eq("userId"));
+        verify(filterService, times(1)).delete(createdFilterId.getValue(), "userId");
+        reset(filterService);
+    }
 }


### PR DESCRIPTION
## PR Summary
- when creating a study, if creating a element in directory server crashes, it removes the study to avoid having orphans



