### PR TITLE
Handle metadata fetching errors gracefully

### DIFF
--- a/src/main/java/org/gridsuite/explore/server/services/IDirectoryElementsService.java
+++ b/src/main/java/org/gridsuite/explore/server/services/IDirectoryElementsService.java
@@ -48,7 +48,7 @@ interface IDirectoryElementsService {
             }).collect(Collectors.toList());
         } catch (ResourceAccessException e) {
             String elementType = lstElementAttribute.isEmpty() ? "UNKNOWN" : lstElementAttribute.getFirst().getType();
-            LOGGER.warn("{} metadata service is unavailable, returning elements with empty specific metadata", elementType, e);
+            LOGGER.warn("{} metadata service is unavailable, returning elements with empty specific metadata", elementType);
             return lstElementAttribute.stream()
                     .map(elementAttributes -> populateMedataItem(elementAttributes, Map.of()))
                     .collect(Collectors.toList());

--- a/src/main/java/org/gridsuite/explore/server/services/IDirectoryElementsService.java
+++ b/src/main/java/org/gridsuite/explore/server/services/IDirectoryElementsService.java
@@ -7,6 +7,9 @@
 package org.gridsuite.explore.server.services;
 
 import org.gridsuite.explore.server.dto.ElementAttributes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.ResourceAccessException;
 
 import java.util.List;
 import java.util.Map;
@@ -20,6 +23,7 @@ import java.util.stream.Collectors;
 
 interface IDirectoryElementsService {
     String HEADER_USER_ID = "userId";
+    Logger LOGGER = LoggerFactory.getLogger(IDirectoryElementsService.class);
 
     default List<Map<String, Object>> getMetadata(List<UUID> uuidList) {
         return uuidList.stream().map(e -> Map.of("id", (Object) e)).collect(Collectors.toList());
@@ -32,15 +36,23 @@ interface IDirectoryElementsService {
         Map<String, ElementAttributes> mapElementAttribute = lstElementAttribute.stream()
                 .collect(Collectors.toMap(e -> e.getElementUuid().toString(), Function.identity()));
         /* getting metadata from services */
-        List<Map<String, Object>> metadata = getMetadata(lstElementAttribute.stream().map(ElementAttributes::getElementUuid).collect(Collectors.toList()));
-        return metadata.stream().map(metadataItem -> {
-            Object item = metadataItem.get("id");
-            if (item == null) {
-                item = metadataItem.getOrDefault("uuid", "");
-            }
-            ElementAttributes e = mapElementAttribute.get(item.toString());
-            return populateMedataItem(e, metadataItem);
-        }).collect(Collectors.toList());
+        try {
+            List<Map<String, Object>> metadata = getMetadata(lstElementAttribute.stream().map(ElementAttributes::getElementUuid).collect(Collectors.toList()));
+            return metadata.stream().map(metadataItem -> {
+                Object item = metadataItem.get("id");
+                if (item == null) {
+                    item = metadataItem.getOrDefault("uuid", "");
+                }
+                ElementAttributes e = mapElementAttribute.get(item.toString());
+                return populateMedataItem(e, metadataItem);
+            }).collect(Collectors.toList());
+        } catch (ResourceAccessException e) {
+            String elementType = lstElementAttribute.isEmpty() ? "UNKNOWN" : lstElementAttribute.getFirst().getType();
+            LOGGER.warn("{} metadata service is unavailable, returning elements with empty specific metadata", elementType, e);
+            return lstElementAttribute.stream()
+                    .map(elementAttributes -> populateMedataItem(elementAttributes, Map.of()))
+                    .collect(Collectors.toList());
+        }
     }
 
     private ElementAttributes populateMedataItem(ElementAttributes elementAttributes, Map<String, Object> metadataItem) {

--- a/src/test/java/org/gridsuite/explore/server/ExploreTest.java
+++ b/src/test/java/org/gridsuite/explore/server/ExploreTest.java
@@ -10,10 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
-import mockwebserver3.Dispatcher;
-import mockwebserver3.MockResponse;
-import mockwebserver3.MockWebServer;
-import mockwebserver3.RecordedRequest;
+import mockwebserver3.*;
 import mockwebserver3.junit5.internal.MockWebServerExtension;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
@@ -83,6 +80,7 @@ class ExploreTest {
     private static final UUID FILTER_UUID = UUID.randomUUID();
     private static final UUID FILTER_UUID_2 = UUID.randomUUID();
     private static final UUID CONTINGENCY_LIST_UUID = UUID.randomUUID();
+    private static final UUID CONTINGENCY_LIST_METADATA_ERROR_UUID = UUID.randomUUID();
     private static final UUID INVALID_ELEMENT_UUID = UUID.randomUUID();
     private static final UUID PARAMETERS_UUID = UUID.randomUUID();
     private static final UUID MODIFICATION_UUID = UUID.randomUUID();
@@ -201,6 +199,7 @@ class ExploreTest {
         String publicStudyAttributesAsString = mapper.writeValueAsString(new ElementAttributes(PUBLIC_STUDY_UUID, STUDY1, "STUDY", USER1, 0, null));
         String invalidElementAsString = mapper.writeValueAsString(new ElementAttributes(INVALID_ELEMENT_UUID, "invalidElementName", "INVALID", USER1, 0, null));
         String formContingencyListAttributesAsString = mapper.writeValueAsString(new ElementAttributes(CONTINGENCY_LIST_UUID, FILTER_CONTINGENCY_LIST, "CONTINGENCY_LIST", USER1, 0, null));
+        String contingencyListMetadataErrorAttributesAsString = mapper.writeValueAsString(new ElementAttributes(CONTINGENCY_LIST_METADATA_ERROR_UUID, "contingencyListInError", "CONTINGENCY_LIST", USER1, 0, null));
         String listOfFormContingencyListAttributesAsString = mapper.writeValueAsString(List.of(new ElementAttributes(CONTINGENCY_LIST_UUID, FILTER_CONTINGENCY_LIST, "CONTINGENCY_LIST", USER1, 0, null)));
         String filterAttributesAsString = mapper.writeValueAsString(new ElementAttributes(FILTER_UUID, FILTER_CONTINGENCY_LIST, FILTER, USER1, 0, null));
         String filter2AttributesAsString = mapper.writeValueAsString(new ElementAttributes(FILTER_UUID_2, FILTER_CONTINGENCY_LIST_2, FILTER, USER1, 0, null));
@@ -297,6 +296,8 @@ class ExploreTest {
                     return new MockResponse(200, Headers.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE), "[" + caseElementAttributesAsString + "]");
                 } else if (path.matches("/v1/elements\\?ids=" + MODIFICATION_UUID) && "GET".equals(request.getMethod())) {
                     return new MockResponse(200, Headers.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE), "[" + modificationElementAttributesAsString + "]");
+                } else if (path.matches("/v1/elements\\?ids=" + CONTINGENCY_LIST_METADATA_ERROR_UUID) && "GET".equals(request.getMethod())) {
+                    return new MockResponse(200, Headers.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE), "[" + contingencyListMetadataErrorAttributesAsString + "]");
                 } else if (path.matches("/v1/filters/metadata\\?ids=" + FILTER_UUID + "," + FILTER_UUID_2) && "GET".equals(request.getMethod())) {
                     return new MockResponse(200, Headers.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE), "[" + mapper.writeValueAsString(specificMetadata) + "," + mapper.writeValueAsString(specificMetadata2) + "]");
                 } else if (path.matches("/v1/elements\\?ids=" + FILTER_UUID + "," + PRIVATE_STUDY_UUID + "," + CONTINGENCY_LIST_UUID) && "GET".equals(request.getMethod())) {
@@ -319,6 +320,10 @@ class ExploreTest {
                     return new MockResponse(200, Headers.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE), elementNamesAsString);
                 } else if (path.matches("/v1/contingency-lists/metadata[?]ids=" + CONTINGENCY_LIST_UUID) && "GET".equals(request.getMethod())) {
                     return new MockResponse(200, Headers.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE), listOfFormContingencyListAttributesAsString.replace("elementUuid", "id"));
+                } else if (path.matches("/v1/contingency-lists/metadata[?]ids=" + CONTINGENCY_LIST_METADATA_ERROR_UUID) && "GET".equals(request.getMethod())) {
+                    return new MockResponse.Builder()
+                            .socketPolicy(SocketPolicy.DisconnectAfterRequest.INSTANCE)
+                            .build();
                 } else if (path.matches("/v1/.*contingency-lists\\?duplicateFrom=" + CONTINGENCY_LIST_UUID) && "POST".equals(request.getMethod())) {
                     return new MockResponse(200, Headers.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE), newContingencyUuidAsString);
                 } else if (path.matches("/v1/form-contingency-lists.*") && "POST".equals(request.getMethod())) {
@@ -944,6 +949,20 @@ class ExploreTest {
         String caseAttributesAsString = mapper.writeValueAsString(new ElementAttributes(CASE_UUID, "case", "CASE", USER1, 0L, null, caseSpecificMetadata));
         assertEquals(1, elementsMetadata.size());
         assertEquals(mapper.writeValueAsString(elementsMetadata.get(0)), caseAttributesAsString);
+    }
+
+    @Test
+    void testGetMetadataReturnsPartialResponseWhenSpecificMetadataLoadingFails() throws Exception {
+        MvcResult result = mockMvc.perform(get("/v1/explore/elements/metadata?ids=" + CONTINGENCY_LIST_METADATA_ERROR_UUID)
+                .header("userId", USER1))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        List<ElementAttributes> elementsMetadata = mapper.readValue(result.getResponse().getContentAsString(), new TypeReference<>() { });
+        assertEquals(1, elementsMetadata.size());
+        assertEquals(CONTINGENCY_LIST_METADATA_ERROR_UUID, elementsMetadata.getFirst().getElementUuid());
+        assertEquals("contingencyListInError", elementsMetadata.getFirst().getElementName());
+        assertTrue(elementsMetadata.getFirst().getSpecificMetadata().isEmpty());
     }
 
     @Test

--- a/src/test/java/org/gridsuite/explore/server/ExploreTest.java
+++ b/src/test/java/org/gridsuite/explore/server/ExploreTest.java
@@ -200,7 +200,8 @@ class ExploreTest {
         String publicStudyAttributesAsString = mapper.writeValueAsString(new ElementAttributes(PUBLIC_STUDY_UUID, STUDY1, "STUDY", USER1, 0, null));
         String invalidElementAsString = mapper.writeValueAsString(new ElementAttributes(INVALID_ELEMENT_UUID, "invalidElementName", "INVALID", USER1, 0, null));
         String formContingencyListAttributesAsString = mapper.writeValueAsString(new ElementAttributes(CONTINGENCY_LIST_UUID, FILTER_CONTINGENCY_LIST, "CONTINGENCY_LIST", USER1, 0, null));
-        String contingencyListMetadataErrorAttributesAsString = mapper.writeValueAsString(new ElementAttributes(CONTINGENCY_LIST_METADATA_ERROR_UUID, "contingencyListInError", "CONTINGENCY_LIST", USER1, 0, null));
+        String contingencyListMetadataErrorAttributesAsString = mapper.writeValueAsString(new ElementAttributes(CONTINGENCY_LIST_METADATA_ERROR_UUID, "contingencyListInError",
+                "CONTINGENCY_LIST", USER1, 0, null));
         String listOfFormContingencyListAttributesAsString = mapper.writeValueAsString(List.of(new ElementAttributes(CONTINGENCY_LIST_UUID, FILTER_CONTINGENCY_LIST, "CONTINGENCY_LIST", USER1, 0,
                 null)));
         String filterAttributesAsString = mapper.writeValueAsString(new ElementAttributes(FILTER_UUID, FILTER_CONTINGENCY_LIST, FILTER, USER1, 0, null));


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
Handle metadata-service connectivity failures by catching ResourceAccessException in IDirectoryElementsService, logging the affected element type, and returning the elements with empty specificMetadata instead of failing the whole request.
This makes it possible to display elements in Gridexplore without having the metadata server up (like actions-server).

